### PR TITLE
Improve event sourcing (#1)

### DIFF
--- a/codegen/impl/src/es/event/mod.rs
+++ b/codegen/impl/src/es/event/mod.rs
@@ -193,6 +193,7 @@ impl Definition {
     pub fn impl_event_sourced(&self) -> TokenStream {
         let ty = &self.ident;
         let (_, ty_gens, _) = self.generics.split_for_impl();
+        let turbofish_gens = ty_gens.as_turbofish();
 
         let var_ty =
             self.variants.iter().flat_map(|v| &v.fields).map(|f| &f.ty);
@@ -203,8 +204,6 @@ impl Definition {
             Self: #( ::arcana::es::event::Sourced<#var_ty> )+*
         });
         let (impl_gens, _, where_clause) = ext_gens.split_for_impl();
-
-        let turbofish_gens = ty_gens.as_turbofish();
 
         let var = self.variants.iter().map(|v| &v.ident);
 

--- a/codegen/impl/src/es/event/mod.rs
+++ b/codegen/impl/src/es/event/mod.rs
@@ -185,7 +185,7 @@ impl Definition {
     }
 
     /// Generates code to derive [`event::Sourced`][0] trait, by simply matching
-    /// each enum variant, which is expected to have itself
+    /// each enum variant, which is expected to have itself an
     /// [`event::Sourced`][0] implementation.
     ///
     /// [0]: arcana_core::es::event::Sourced
@@ -195,6 +195,7 @@ impl Definition {
         let (_, ty_gens, _) = self.generics.split_for_impl();
         let turbofish_gens = ty_gens.as_turbofish();
 
+        let var = self.variants.iter().map(|v| &v.ident);
         let var_ty =
             self.variants.iter().flat_map(|v| &v.fields).map(|f| &f.ty);
 
@@ -204,8 +205,6 @@ impl Definition {
             Self: #( ::arcana::es::event::Sourced<#var_ty> )+*
         });
         let (impl_gens, _, where_clause) = ext_gens.split_for_impl();
-
-        let var = self.variants.iter().map(|v| &v.ident);
 
         let unreachable_arm = self.has_ignored_variants.then(|| {
             quote! { _ => unreachable!(), }
@@ -218,9 +217,11 @@ impl Definition {
             {
                 fn apply(&mut self, event: &#ty#ty_gens) {
                     match event {
-                        #(#ty#turbofish_gens::#var(f) => {
-                            ::arcana::es::event::Sourced::apply(self, f)
-                        },)*
+                        #(
+                            #ty#turbofish_gens::#var(f) => {
+                                ::arcana::es::event::Sourced::apply(self, f);
+                            },
+                        )*
                         #unreachable_arm
                     }
                 }
@@ -359,10 +360,10 @@ mod spec {
                 fn apply(&mut self, event: &Event) {
                     match event {
                         Event::File(f) => {
-                            ::arcana::es::event::Sourced::apply(self, f)
+                            ::arcana::es::event::Sourced::apply(self, f);
                         },
                         Event::Chat(f) => {
-                            ::arcana::es::event::Sourced::apply(self, f)
+                            ::arcana::es::event::Sourced::apply(self, f);
                         },
                     }
                 }
@@ -483,10 +484,10 @@ mod spec {
                 fn apply(&mut self, event: &Event<'a, F, C>) {
                     match event {
                         Event::<'a, F, C>::File(f) => {
-                            ::arcana::es::event::Sourced::apply(self, f)
+                            ::arcana::es::event::Sourced::apply(self, f);
                         },
                         Event::<'a, F, C>::Chat(f) => {
-                            ::arcana::es::event::Sourced::apply(self, f)
+                            ::arcana::es::event::Sourced::apply(self, f);
                         },
                     }
                 }
@@ -620,10 +621,10 @@ mod spec {
                 fn apply(&mut self, event: &Event) {
                     match event {
                         Event::File(f) => {
-                            ::arcana::es::event::Sourced::apply(self, f)
+                            ::arcana::es::event::Sourced::apply(self, f);
                         },
                         Event::Chat(f) => {
-                            ::arcana::es::event::Sourced::apply(self, f)
+                            ::arcana::es::event::Sourced::apply(self, f);
                         },
                         _ => unreachable!(),
                     }

--- a/codegen/shim/src/lib.rs
+++ b/codegen/shim/src/lib.rs
@@ -105,6 +105,7 @@ use proc_macro::TokenStream;
 /// ```
 ///
 /// [`Event`]: arcana_core::es::Event
+/// [`Sourced`]: arcana_core::es::event::Sourced
 /// [`Versioned`]: arcana_core::es::event::Versioned
 /// [0]: arcana_core::es::Event::name()
 /// [1]: arcana_core::es::Event::version()

--- a/codegen/shim/src/lib.rs
+++ b/codegen/shim/src/lib.rs
@@ -35,8 +35,8 @@ use proc_macro::TokenStream;
 /// is that all the underlying [`Event`] or [`Versioned`] impls should be
 /// derived too.
 ///
-/// Also provides [`Sourced`] impl for every state, which can be sourced from
-/// all variants.
+/// Also, provides a blanket [`Sourced`] implementation for every state, which
+/// can be sourced from all the enum variants.
 ///
 /// > __WARNING:__ Currently may not work with complex generics using where
 /// >              clause because of `const` evaluation limitations. Should be
@@ -90,7 +90,7 @@ use proc_macro::TokenStream;
 /// #[derive(Event)]
 /// enum AnyEvent {
 ///     Chat(ChatEvent),
-///     #[event(ignore)] // Not recommended for real usage.
+///     #[event(ignore)] // not recommended for real usage
 ///     DuplicateChat(DuplicateChatEvent),
 /// }
 ///

--- a/codegen/shim/src/lib.rs
+++ b/codegen/shim/src/lib.rs
@@ -35,6 +35,9 @@ use proc_macro::TokenStream;
 /// is that all the underlying [`Event`] or [`Versioned`] impls should be
 /// derived too.
 ///
+/// Also provides [`Sourced`] impl for every state, which can be sourced from
+/// all variants.
+///
 /// > __WARNING:__ Currently may not work with complex generics using where
 /// >              clause because of `const` evaluation limitations. Should be
 /// >              lifted once [rust-lang/rust#57775] is resolved.
@@ -87,7 +90,7 @@ use proc_macro::TokenStream;
 /// #[derive(Event)]
 /// enum AnyEvent {
 ///     Chat(ChatEvent),
-///     #[event(ignore)]
+///     #[event(ignore)] // Not recommended for real usage.
 ///     DuplicateChat(DuplicateChatEvent),
 /// }
 ///

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,6 +22,9 @@ derive_more = { version = "0.99", features = ["deref", "deref_mut", "display", "
 ref-cast = "1.0"
 sealed = { version = "0.3", optional = true }
 
+[dev-dependencies]
+arcana = { version = "0.1.0-dev", path = "..", features = ["derive", "es"] }
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/core/src/es/mod.rs
+++ b/core/src/es/mod.rs
@@ -7,6 +7,6 @@ pub mod event;
 #[doc(inline)]
 pub use self::event::{
     Event, Initial as InitialEvent, Initialized as EventInitialized,
-    Name as EventName, Sourced as EventSourced, Version as EventVersion,
-    Versioned as VersionedEvent,
+    Name as EventName, Sourced as EventSourced, Sourcing as EventSourcing,
+    Version as EventVersion, Versioned as VersionedEvent,
 };

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -1,4 +1,4 @@
-use arcana::es::event::{self, Event, Initial, Sourced as _};
+use arcana::es::event::{self, Event, Initial, Initialized, Sourced, Sourcing};
 
 #[derive(event::Versioned)]
 #[event(name = "chat.created", version = 1)]
@@ -26,26 +26,53 @@ enum AnyEvent {
 }
 
 #[derive(Debug, Eq, PartialEq)]
+struct Chat {
+    message_count: usize,
+}
+
+impl Initialized<ChatCreated> for Chat {
+    fn init(_: &ChatCreated) -> Self {
+        Self { message_count: 0 }
+    }
+}
+
+impl Sourced<MessagePosted> for Chat {
+    fn apply(&mut self, _: &MessagePosted) {
+        self.message_count += 1;
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
 struct Message;
 
-impl event::Initialized<MessagePosted> for Message {
+impl Initialized<MessagePosted> for Message {
     fn init(_: &MessagePosted) -> Self {
         Self
     }
 }
 
 fn main() {
+    let mut chat = Option::<Chat>::None;
+    let mut message = Option::<Message>::None;
+
     let ev = ChatEvent::Created(ChatCreated.into());
+    chat.apply(&ev);
     assert_eq!(ev.name(), "chat.created");
+    assert_eq!(chat, Some(Chat { message_count: 0 }));
 
     let ev = ChatEvent::MessagePosted(MessagePosted);
+    chat.apply(&ev);
     assert_eq!(ev.name(), "message.posted");
+    assert_eq!(chat, Some(Chat { message_count: 1 }));
+
+    let ev: &dyn Sourcing<Option<Chat>> = &ev;
+    chat.apply(ev);
+    assert_eq!(chat, Some(Chat { message_count: 2 }));
 
     let ev = MessageEvent::MessagePosted(MessagePosted.into());
-    let mut msg: Option<Message> = None;
-    msg.apply(&ev);
-    assert_eq!(msg, Some(Message));
+    message.apply(&ev);
     assert_eq!(ev.name(), "message.posted");
+    assert_eq!(message, Some(Message));
 
     let ev = AnyEvent::Chat(ChatEvent::Created(ChatCreated.into()));
     assert_eq!(ev.name(), "chat.created");

--- a/examples/event.rs
+++ b/examples/event.rs
@@ -14,6 +14,15 @@ enum ChatEvent {
     MessagePosted(MessagePosted),
 }
 
+impl<T> event::Sourced<ChatEvent> for Option<T>
+where Self: event::Sourced<Initial<ChatCreated>> +
+            event::Sourced<MessagePosted>
+{
+    fn apply(&mut self, event: &ChatEvent) {
+        unimplemented!()
+    }
+}
+
 #[derive(Event)]
 enum MessageEvent {
     MessagePosted(Initial<MessagePosted>),

--- a/src/es/event.rs
+++ b/src/es/event.rs
@@ -2,7 +2,7 @@
 
 #[doc(inline)]
 pub use arcana_core::es::event::{
-    Event, Initial, Initialized, Name, Sourced, Version, Versioned,
+    Event, Initial, Initialized, Name, Sourced, Sourcing, Version, Versioned,
 };
 
 #[cfg(feature = "derive")]

--- a/src/es/mod.rs
+++ b/src/es/mod.rs
@@ -7,6 +7,6 @@ pub mod event;
 #[doc(inline)]
 pub use self::event::{
     Event, Initial as InitialEvent, Initialized as EventInitialized,
-    Name as EventName, Sourced as EventSourced, Version as EventVersion,
-    Versioned as VersionedEvent,
+    Name as EventName, Sourced as EventSourced, Sourcing as EventSourcing,
+    Version as EventVersion, Versioned as VersionedEvent,
 };


### PR DESCRIPTION
Part of #1




## Synopsis

For now deriving `Event` implements only `Event` itself without helping with `Sourcing` of those `Event`s.




## Solution

Derive `Sourced` for `Event` derivers and add `Sourcing` trait for better dynamic dispatch.




## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains `Draft: ` prefix
    - [x] Name contains issue reference
    - [x] Has `k::` labels applied
    - [x] Has assignee
- [x] Documentation is updated (if required)
- [x] Tests are updated (if required)
- [x] Changes conform code style
- [x] CHANGELOG entry is added (if required)
- [x] FCM (final commit message) is posted
    - [x] and approved
- [x] [Review][l:2] is completed and changes are approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] `Draft: ` prefix is removed
    - [x] All temporary labels are removed





[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests
